### PR TITLE
proportions: Fix lookup of gateway mac

### DIFF
--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -120,7 +120,7 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
       var nodes = onlineNodes.concat(data.nodes.lost)
       var nodeDict = {}
       data.graph.nodes.forEach(function (d) {
-        nodeDict[d.id.substr(0, 8)] = d
+        nodeDict[d.id.substr(0, 17)] = d
       })
 
       var statusDict = count(nodes, ["flags", "online"], function (d) {
@@ -155,7 +155,7 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
         if (d === null)
           return null
 
-        var n = nodeDict[d.substr(0, 8)]
+        var n = nodeDict[d.substr(0, 17)]
         if (!n)
           return d
         var name = dictGet(n, ["node", "nodeinfo", "hostname"])
@@ -169,7 +169,7 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
         if (d === null)
           return null
 
-        var n = nodeDict[d.substr(0, 8)]
+        var n = nodeDict[d.substr(0, 17)]
         if (!n)
           return d
         var name = dictGet(n, ["node", "nodeinfo", "hostname"])


### PR DESCRIPTION
The mac address in gateway and gateway_nexthop is 17 characters long. 17 characters have therefore to be used for the lookup and not only 8.

----
Just noticed that your current installation of hopglass on https://vogtland.freifunk.net/map/ merges the vpn01, vpn02 and vpn04 statistics into a single value. This should be fixed to work like https://vpn01.freifunk-vogtland.net/hopglass/. The modified app.js can be found under https://vpn01.freifunk-vogtland.net/hopglass/app.js

@SunboX please check if it works and then merge this + update the installation under https://vogtland.freifunk.net/map/